### PR TITLE
Fix typo in link.py

### DIFF
--- a/moonraker_obico/link.py
+++ b/moonraker_obico/link.py
@@ -54,7 +54,7 @@ To abort, simply press 'Enter'.
             data = resp.json()
             auth_token = data['printer']['auth_token']
             config.update_server_auth_token(auth_token)
-            print('\n###### Sccuessfully linked to your Obico Server account!')
+            print('\n###### Successfully linked to your Obico Server account!')
             break
         except Exception:
             print(RED + '\n==== Failed to link. Did you enter an expired code? ====\n' + NC)


### PR DESCRIPTION
'Sccuessfully' to 'Successfully'