### PR TITLE
Drop existing loghandlers when reconfiguring logging

### DIFF
--- a/moonraker_obico/logger.py
+++ b/moonraker_obico/logger.py
@@ -3,6 +3,7 @@ import logging.handlers
 import sys
 
 def setup_logging(logging_config):
+    handlers = []
     log_level_info = {'DEBUG': logging.DEBUG,
                       'INFO': logging.INFO,
                       'WARNING': logging.WARNING,
@@ -16,12 +17,19 @@ def setup_logging(logging_config):
         "%(asctime)s  %(levelname)8s  %(name)s - %(message)s"
     )
 
+
     sh = logging.StreamHandler(sys.stdout)
     sh.setFormatter(formatter)
-    logger.addHandler(sh)
+    handlers.append(sh)
 
     if logging_config.path:
         fh = logging.handlers.RotatingFileHandler(
             logging_config.path, maxBytes=100000000, backupCount=5)
         fh.setFormatter(formatter)
-        logger.addHandler(fh)
+        handlers.append(fh)
+
+    for hdlr in logger.handlers[:]:
+        logger.removeHandler(hdlr)
+
+    for hdlr in handlers:
+        logger.addHandler(hdlr)


### PR DESCRIPTION
Calls to setup_logging always created and attached a new set of handlers.

When waiting for a working auth_token, current logic keeps reconfiguring
logging, according to the actual content of the cfg file.

It would be possible to extract logging setup out of that loop, but I
went with this solution: dropping existing handlers when setting up root
handler.

Fixes #41.