### PR TITLE
INSTALL: generate always a own virtual-env for moonraker-obico

### DIFF
--- a/moonraker-obico-update.cfg.sample
+++ b/moonraker-obico-update.cfg.sample
@@ -2,7 +2,7 @@
 type: git_repo
 path: ~/moonraker-obico
 origin: https://github.com/TheSpaghettiDetective/moonraker-obico.git
-env: ~/moonraker-env/bin/python
+env: ~/moonraker-obico-env/bin/python
 requirements: requirements.txt
 install_script: install.sh
 managed_services:

--- a/scripts/funcs.sh
+++ b/scripts/funcs.sh
@@ -10,8 +10,8 @@ cyan=$(echo -en "\e[96m")
 default=$(echo -en "\e[39m")
 
 ensure_venv() {
-  if [ -f "${HOME}/moonraker-env/bin/activate" ] ; then
-    OBICO_ENV="${HOME}/moonraker-env"
+  if [ -f "${HOME}/moonraker-obico-env/bin/activate" ] ; then
+    OBICO_ENV="${HOME}/moonraker-obico-env"
   else
     OBICO_ENV="${HOME}/moonraker-obico-env"
     report_status "Creating python virtual environment for moonraker-obico..."


### PR DESCRIPTION
moonraker-obico will always generate a own virtual-env while installation. This change avoids conflicts between moonraker and moonraker-obico during updates in the virtual-env.

Tested on a fresh install and with a install without linking (./install.sh -L)

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com