### PR TITLE
ffmpeg stream to match FPS of moonraker's camera or allow override in cfg file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,12 @@ discover_sys_settings() {
     return 1
   fi
 
+  # Could improve handling if more than one webcam is configured
+  # 2023-02-01 If a second webcam is added, the FPS is in quotes, compared to the first that does not, which is found here
+  if ! mr_fps=$(curl -s "http://${MOONRAKER_HOST}:${mr_port}/server/webcams/list" | grep -oP '"target_fps": \K\d+') ; then
+    mr_fps=25
+  fi
+
   toolchain_msg=""
   if echo $mr_database | grep -qi 'mainsail' ; then
     toolchain_msg="${toolchain_msg} Mainsail installed"
@@ -208,6 +214,7 @@ port = ${MOONRAKER_PORT}
 
 [webcam]
 disable_video_streaming = False
+fps = ${mr_fps}
 
 # CAUTION: Don't modify the settings below unless you know what you are doing
 #   In most cases webcam configuration will be automatically retrived from moonraker

--- a/install.sh
+++ b/install.sh
@@ -98,12 +98,6 @@ discover_sys_settings() {
     return 1
   fi
 
-  # Could improve handling if more than one webcam is configured
-  # 2023-02-01 If a second webcam is added, the FPS is in quotes, compared to the first that does not, which is found here
-  if ! mr_fps=$(curl -s "http://${MOONRAKER_HOST}:${mr_port}/server/webcams/list" | grep -oP '"target_fps": \K\d+') ; then
-    mr_fps=25
-  fi
-
   toolchain_msg=""
   if echo $mr_database | grep -qi 'mainsail' ; then
     toolchain_msg="${toolchain_msg} Mainsail installed"
@@ -214,7 +208,7 @@ port = ${MOONRAKER_PORT}
 
 [webcam]
 disable_video_streaming = False
-fps = ${mr_fps}
+# fps = 25
 
 # CAUTION: Don't modify the settings below unless you know what you are doing
 #   In most cases webcam configuration will be automatically retrived from moonraker

--- a/moonraker-obico.cfg.sample
+++ b/moonraker-obico.cfg.sample
@@ -10,7 +10,7 @@ port = 7125
 
 [webcam]
 disable_video_streaming = False
-fps = 25
+# fps = 25
 
 # flip_h = False
 # flip_v = False

--- a/moonraker-obico.cfg.sample
+++ b/moonraker-obico.cfg.sample
@@ -10,6 +10,7 @@ port = 7125
 
 [webcam]
 disable_video_streaming = False
+fps = 25
 
 # flip_h = False
 # flip_v = False
@@ -17,7 +18,7 @@ disable_video_streaming = False
 # aspect_ratio_169 = False
 
 # CAUTION: Don't modify the settings below unless you know what you are doing
-#   In most cases webcam configuration will be automatically retrived from moonraker
+#   In most cases webcam configuration will be automatically retrieved from moonraker
 #
 # snapshot_url = http://127.0.0.1:8080/?action=snapshot
 # stream_url = http://127.0.0.1:8080/?action=stream

--- a/moonraker_obico/app.py
+++ b/moonraker_obico/app.py
@@ -233,7 +233,7 @@ class App(object):
 
             elif event.data.get('method', '') == 'notify_gcode_response':
                 msg = (event.data.get('params') or [''])[0]
-                if msg.startswith('!!'):  # It seems to an undocumented feature that some gcode errors that are critical for the users to know are recevied as notify_gcode_response with "!!"
+                if msg.startswith('!!'):  # It seems to an undocumented feature that some gcode errors that are critical for the users to know are received as notify_gcode_response with "!!"
                     self.server_conn.post_printer_event_to_server('Moonraker Error', msg, attach_snapshot=True)
 
         elif event.name == 'status_update':

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -67,6 +67,10 @@ class WebcamConfig:
         return self.webcam_config_section.getboolean('disable_video_streaming', False)
 
     @property
+    def fps(self):
+        return self.webcam_config_section.get('fps')
+
+    @property
     def snapshot_ssl_validation(self):
         return False
 

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -68,7 +68,7 @@ class WebcamConfig:
 
     @property
     def fps(self):
-        return self.webcam_config_section.get('fps')
+        return self.webcam_config_section.get('fps') or self.moonraker_webcam_config.get('target_fps')
 
     @property
     def snapshot_ssl_validation(self):

--- a/moonraker_obico/moonraker_conn.py
+++ b/moonraker_obico/moonraker_conn.py
@@ -115,6 +115,7 @@ class MoonrakerConn:
                 # TODO: Just pick the last webcam before we have a way to support multiple cameras
                 for cfg in result.get('value', {}).values():
                     return dict(
+                        target_fps = cfg.get('targetFps', 25),
                         snapshot_url = cfg.get('urlSnapshot', None),
                         stream_url = cfg.get('urlStream', None),
                         flip_h = cfg.get('flipX', False),
@@ -131,6 +132,7 @@ class MoonrakerConn:
                         continue
 
                     return dict(
+                        target_fps = cfg.get('target_fps', 25),  # TODO Verify the key name in fluidd for FPS
                         stream_url = cfg.get('url', None),
                         flip_h = cfg.get('flipX', False),
                         flip_v = cfg.get('flipY', False),

--- a/moonraker_obico/printer.py
+++ b/moonraker_obico/printer.py
@@ -77,7 +77,7 @@ class PrinterState:
             'paused': PrinterState.STATE_PAUSED,
             'complete': PrinterState.STATE_OPERATIONAL,
             'cancelled': PrinterState.STATE_OPERATIONAL,
-            'error': PrinterState.STATE_OPERATIONAL, # state is "error" when printer quits a print due to an error, but opertional
+            'error': PrinterState.STATE_OPERATIONAL, # state is "error" when printer quits a print due to an error, but operational
         }.get(data.get('print_stats', {}).get('state', 'unknown'), PrinterState.STATE_OFFLINE)
 
     def to_dict(

--- a/moonraker_obico/printer_discovery.py
+++ b/moonraker_obico/printer_discovery.py
@@ -94,7 +94,7 @@ class PrinterDiscovery(object):
                 if steps_remaining % POLL_PERIOD == 0:
                     self._call()
             except (IOError, OSError) as ex:
-                # tyring to catch only network related errors here,
+                # trying to catch only network related errors here,
                 # all other errors must bubble up.
 
                 # http4xx can be an actionable bug, let it bubble up
@@ -180,7 +180,7 @@ class PrinterDiscovery(object):
             #result = verify_code(self.plugin, {'code': code})
 
 #            if result['succeeded'] is True:
-#                _logger.info('printer_discovery verified code succesfully')
+#                _logger.info('printer_discovery verified code successfully')
 #                self.plugin._plugin_manager.send_plugin_message(
 #                    self.plugin._identifier, {'printer_autolinked': True})
 #            else:
@@ -196,7 +196,7 @@ class PrinterDiscovery(object):
 
     def _collect_device_info(self):
         info = dict(**self.static_info)
-        info['printerprofile'] = 'Unkown'
+        info['printerprofile'] = 'Unknown'
         info['machine_type'] = 'Klipper'
         return info
 

--- a/moonraker_obico/webcam_stream.py
+++ b/moonraker_obico/webcam_stream.py
@@ -142,7 +142,7 @@ class WebcamStreamer:
 
 
         bitrate = bitrate_for_dim(img_w, img_h)
-        fps = 25
+        fps = webcam_config.fps
         if not self.app_model.linked_printer.get('is_pro'):
             fps = 5
             bitrate = int(bitrate/4)

--- a/moonraker_obico/webcam_stream.py
+++ b/moonraker_obico/webcam_stream.py
@@ -91,7 +91,7 @@ class WebcamStreamer:
 
     def video_pipeline(self):
         if not pi_version():
-            _logger.warning('Not running on a Pi. Quiting video_pipeline.')
+            _logger.warning('Not running on a Pi. Quitting video_pipeline.')
             return
 
         try:
@@ -113,7 +113,7 @@ class WebcamStreamer:
         def get_webcam_resolution(webcam_config):
             jpg = capture_jpeg(webcam_config, force_stream_url=True)
             if not jpg:
-                raise Exception('Not a valid jpeg source. Quiting ffmpeg.')
+                raise Exception('Not a valid jpeg source. Quitting ffmpeg.')
 
             return get_image_info(jpg)
 


### PR DESCRIPTION
This PR retrieves the target fps configured in moonraker for the first webcam and configures Obico streaming to match the same FPS.  If a user is selecting a lower FPS in Moonraker/Mainsail/Fluidd, there should be no reason for Obico to default to a higher/different value.

Reads the Moonraker API for the current FPS and uses it.  I do not use Fluidd so need to verify what the API key is named for the Fluidd version.  Defaults to 25 FPS if it cannot find it to match current functionality

Also allows for a new configuration value in moonraker-obico.cfg under the [webcam] section to allow a user to define a different fps value for Obico streaming without modifying the Moonraker config
If this PR is merged in, I can update the Documentation in obico-server repo to reflect the new option.

Also a few spelling corrections I found.

Question:
Today in moonraker-conn.py at line 112 it is using the server.database.list with a namespace of webcams which apparently does work, but the current API documentation has a separate endpoint just for webcams.  Would it be better to use this endpoint directly as it makes more logical sense to me.  Would be a separate PR for that modification
https://moonraker.readthedocs.io/en/latest/web_api/#webcam-apis
