### PR TITLE
Use python-virtualenv, not python-venv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ ensure_deps() {
   report_status "Installing required system packages... You may be prompted to enter password."
 
   # PKGLIST="python3 python3-pip python3-venv ffmpeg janus"
-  PKGLIST="python3 python3-pip python3-venv ffmpeg"
+  PKGLIST="python3 python3-pip python3-virtualenv ffmpeg"
   sudo apt-get update --allow-releaseinfo-change
   sudo apt-get install --yes ${PKGLIST}
   # sudo systemctl stop janus


### PR DESCRIPTION
`scripts/funcs.sh` calls `virtualenv`; however, the `python-venv` package does not actually provide that command on my Debian 11.

The correct package is `python-virtualenv`.