### PR TITLE
Fix docker dependencies

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "master"
+    tags:
+      - "*"
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN python -m venv venv \
 FROM python:3-slim-bookworm
 
 RUN apt update \
- && apt install -y ffmpeg \
+ && apt install -y janus ffmpeg \
  && apt clean
 
 WORKDIR /opt


### PR DESCRIPTION
This PR adds janus to the runtime image to get rid of the following messages: 

```
2023-09-07 08:06:27,805   WARNING  obico.janus - Janus setup failed. Skipping Janus connection. Error: 
b"dpkg-query: package 'janus' is not installed\nUse dpkg --contents (= dpkg-deb --contents) to list archive files contents.\n"
2023-09-07 08:06:27,984      INFO  obico.app - detected state change: Offline -> Operational
2023-09-07 08:06:28,451      INFO  backoff - Backing off wait_for_janus(...) for 0.7s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:06:30,193      INFO  backoff - Backing off wait_for_janus(...) for 1.8s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:06:32,984      INFO  backoff - Backing off wait_for_janus(...) for 3.1s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:06:37,097      INFO  backoff - Backing off wait_for_janus(...) for 4.4s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:06:42,491      INFO  backoff - Backing off wait_for_janus(...) for 11.9s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:06:55,392      INFO  backoff - Backing off wait_for_janus(...) for 19.1s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:07:15,526      INFO  backoff - Backing off wait_for_janus(...) for 32.7s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:07:49,194      INFO  backoff - Backing off wait_for_janus(...) for 33.1s (ConnectionRefusedError: [Errno 111] Connection refused)
2023-09-07 08:08:23,254      INFO  backoff - Backing off wait_for_janus(...) for 79.0s (ConnectionRefusedError: [Errno 111] Connection refused)

```

Furthermore, the ci job is set up to also run when new tags are added, creating tagged docker images for each release. 

-Markus