### PR TITLE
Docker: fix video permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt update \
 
 WORKDIR /opt
 RUN groupadd obico --gid 1000 \
- && useradd obico --uid 1000 --gid obico
+ && useradd obico --uid 1000 --gid obico \
+ && usermod obico --append --groups video
 RUN mkdir -p printer_data/config printer_data/logs \
  && chown -R obico:obico /opt/*
 

--- a/run_as_container.md
+++ b/run_as_container.md
@@ -26,11 +26,12 @@ docker run --rm -it \
 
 ## Run the application
 
-Given, that your moonraker-obico.cfg now contains a valid `[server].auth_token`, a container may be started using the following command:
+Given that your moonraker-obico.cfg now contains a valid `[server].auth_token`, a container may be started using the following command:
 
 ```bash
 docker run -d \
   --name moonraker-obico \
+  --privileged \
   -v /opt/mydir/moonraker-obico.cfg:/opt/printer_data/config/moonraker-obico.cfg \
   ghcr.io/thespaghettidetective/moonraker-obico:latest
 ```


### PR DESCRIPTION
As we found out in https://github.com/mkuf/prind/issues/93, moonraker-obico may use a Raspberry Pis video encoder to stream the webcam continuously, even if the process is running in Docker.  

This PR adds the `obico` user to the `video` group within the container, thus allowing the non-root-user to access the hosts video devices as long as the container is run in privileged mode.  
The example command in the Docs has also been updated to start the container in privileged Mode. 