### PR TITLE
update MjpegStreamChunker to not parse empty lines as the mjpeg boundary

### DIFF
--- a/moonraker_obico/webcam_capture.py
+++ b/moonraker_obico/webcam_capture.py
@@ -92,11 +92,15 @@ class MjpegStreamChunker:
         #         None: in the middle of the chunk
         # The first time endOfChunk should be called
         # with 'boundary' text as input
+        if not len(line.strip()): # don't parse empty lines as the boundary
+            self.current_chunk.write(line)
+            return None
+        
         if not self.boundary:
             self.boundary = line
             self.current_chunk.write(line)
             return None
-
+        
         if len(line) == len(self.boundary) and line == self.boundary:
             # start of next chunk
             return self.current_chunk.getvalue()

--- a/moonraker_obico/webcam_capture.py
+++ b/moonraker_obico/webcam_capture.py
@@ -100,7 +100,7 @@ class MjpegStreamChunker:
             self.boundary = line
             self.current_chunk.write(line)
             return None
-        
+
         if len(line) == len(self.boundary) and line == self.boundary:
             # start of next chunk
             return self.current_chunk.getvalue()


### PR DESCRIPTION
vlc-provided mjpeg streams (like the one provided by [this](https://github.com/bwnance/rtsp-to-mjpeg) didn't work due to some weirdness in how they serve the mjpeg stream. this is a small patch to allow moonraker-obico to work with vlc streams