### PR TITLE
Fix bash shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/moonraker_obico/bin/ffmpeg/run.sh
+++ b/moonraker_obico/bin/ffmpeg/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/moonraker_obico/bin/utils.sh
+++ b/moonraker_obico/bin/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 debian_release() {
   cat /etc/debian_version | cut -d '.' -f1

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export OBICO_DIR=$(readlink -f $(dirname "$0"))/..
 

--- a/scripts/migrated_from_tsd.sh
+++ b/scripts/migrated_from_tsd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KLIPPER_CONF_DIR="$1"
 OBICO_ENV="$2"

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set DEBUG=True for faster pic and status update
 # DEBUG=True ../moonraker-obico-env/bin/python3 -m moonraker_obico.app $@

--- a/scripts/tsd_service_existed.sh
+++ b/scripts/tsd_service_existed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KLIPPER_CONF_DIR="$1"
 SYSTEMDDIR="/etc/systemd/system"


### PR DESCRIPTION
I have an Ender-3 V3, which doesn't have bash installed by default. I've installed bash with Entware, which puts bash into `/opt/bin/bash` instead of `/bin/bash`.

Using `/usr/bin/env bash` instead of `/bin/bash`  allows these scripts to run normally, regardless of where bash is actually installed in the user's PATH