### PR TITLE
Reuse the snapshot HTTP connection instead of reconnecting every frame

### DIFF
--- a/moonraker_obico/webcam_capture.py
+++ b/moonraker_obico/webcam_capture.py
@@ -22,6 +22,32 @@ if DEBUG:
 _logger = logging.getLogger('obico.webcam_capture')
 
 
+_thread_local = threading.local()
+
+
+def _snapshot_session():
+    # Reuse one keep-alive connection per thread. Each webcam gets its own
+    # capture thread, so this yields one persistent connection per camera and
+    # avoids a fresh TCP (and, for https snapshot_urls, TLS) handshake on
+    # every single frame.
+    session = getattr(_thread_local, 'snapshot_session', None)
+    if session is None:
+        session = requests.Session()
+        session.verify = False
+        _thread_local.snapshot_session = session
+    return session
+
+
+def _reset_snapshot_session():
+    session = getattr(_thread_local, 'snapshot_session', None)
+    if session is not None:
+        try:
+            session.close()
+        except Exception:
+            pass
+        _thread_local.snapshot_session = None
+
+
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 @backoff.on_predicate(backoff.expo, max_tries=3)
 def capture_jpeg(webcam_config, force_stream_url=False):
@@ -29,19 +55,26 @@ def capture_jpeg(webcam_config, force_stream_url=False):
 
     snapshot_url = webcam_config.snapshot_url
     if snapshot_url and not force_stream_url:
-        r = requests.get(snapshot_url, stream=True, timeout=5, verify=False)
-        r.raise_for_status()
+        try:
+            r = _snapshot_session().get(snapshot_url, stream=True, timeout=5)
+            r.raise_for_status()
 
-        response_content = b''
-        start_time = time.monotonic()
-        for chunk in r.iter_content(chunk_size=1024):
-            response_content += chunk
-            if len(response_content) > MAX_JPEG_SIZE:
-                r.close()
-                raise Exception('Payload returned from the snapshot_url is too large. Did you configure stream_url as snapshot_url?')
+            chunks = []
+            total_size = 0
+            for chunk in r.iter_content(chunk_size=65536):
+                chunks.append(chunk)
+                total_size += len(chunk)
+                if total_size > MAX_JPEG_SIZE:
+                    r.close()
+                    raise Exception('Payload returned from the snapshot_url is too large. Did you configure stream_url as snapshot_url?')
 
-        r.close()
-        return response_content
+            r.close()
+            return b''.join(chunks)
+        except Exception:
+            # Drop the pooled connection so a half-open socket is not reused
+            # by the backoff retry.
+            _reset_snapshot_session()
+            raise
 
     else:
         stream_url = webcam_config.stream_url


### PR DESCRIPTION
# Reuse the snapshot HTTP connection instead of reconnecting every frame

## Problem

`capture_jpeg()` calls the module-level `requests.get()` for every frame. That
opens a **new TCP connection — and for an `https` snapshot_url, a full TLS
handshake — on every single frame**, for every camera, continuously while
streaming.

It also accumulates the response with `response_content += chunk` over 1 KB
chunks, which is O(n²) in the frame size.

The same codebase already establishes the pattern this PR applies:
`tunnel.py:33` uses `requests.Session()`.

## Impact

On a low-power printer host this consumes a large fraction of a core. Measured
on an Elegoo Neptune 4 Plus (Rockchip RK3328, 4 cores) with three cameras
served over https:

| | moonraker-obico CPU |
|---|---|
| before | **94 % of a core** |
| after  | **21 % of a core** |

Per-thread, the three `mjpeg_loop` threads went from 39 % / 22 % / 33 % to
8 % / 6 % / 7 %.

Isolated micro-benchmark of `capture_jpeg`'s snapshot path alone, 30 frames of
a ~50 KB JPEG over https on the same hardware:

| | wall/frame | CPU/frame |
|---|---|---|
| `requests.get()` + `+=` | 130.6 ms | **121.0 ms** |
| `Session` + `b''.join()` | 13.9 ms | **11.3 ms** |

~10.7x less CPU in the capture path itself.

Sustained since: 14.5 hours continuous with three cameras, zero snapshot
errors, averaging 24 % of a core over process lifetime.

### Context

This was found while investigating host CPU saturation on a 4-core printer
host, where moonraker-obico was the single largest consumer. I want to be
careful not to overstate the case: I initially suspected this was also causing
Klipper `Missed scheduling of next digital out event` aborts on my machine, but
that turned out to have a separate cause (an RT priority inversion on the
serial IRQ thread), and aborts still occurred with moonraker-obico stopped. So
this PR is offered purely as a CPU/efficiency fix, not as a fix for Klipper
timing faults.

That said, on constrained hosts freeing ~70 % of a core is worth having, and it
may be relevant to #34.

## Change

- One `requests.Session` per capture thread, kept in a `threading.local()`.
  Each webcam already runs its own capture thread, so this is one persistent
  connection per camera.
- Accumulate into a list and `b''.join()` once; 64 KB read chunks.
- On any exception the pooled session is closed and dropped, so the `backoff`
  retry cannot reuse a half-open socket.

`verify=False` is preserved on the session to keep existing behaviour
unchanged. An unused `start_time = time.monotonic()` (already dead code) is
removed.

## Notes / possible follow-up

Not changed here, but worth flagging: `mjpeg_loop()` in `webcam_stream.py`
sleeps `bandwidth_throttle` (4 ms) after **every 1400-byte chunk**. For a 50 KB
JPEG (~67 KB base64, ~48 chunks) that is ~190 ms of forced sleep per frame, so
throughput is capped near 5 fps regardless of `target_fps`, and it generates
roughly 240 timer wakeups per second per camera. Throttling by elapsed time or
bytes rather than a fixed per-chunk sleep would likely help further, but it
changes bandwidth behaviour so it is out of scope for this PR.
